### PR TITLE
Init/#19 init setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/mody-favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0,maximum-scale=1.0,minimum-scale=1,user-scalable=0"
+    />
     <title>Mody - 내 손 안에 패션 메이트</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@tanstack/eslint-plugin-query": "^5.62.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
-        "@vitejs/plugin-react-swc": "^3.5.0",
+        "@vitejs/plugin-react-swc": "^3.7.2",
         "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^9.15.0",
         "eslint-config-prettier": "^9.1.0",
@@ -34,6 +34,21 @@
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.15.0",
         "vite": "^6.0.1"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -49,6 +64,60 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.26.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
+      "integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+      "integrity": "sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.0",
+        "@babel/generator": "^7.26.0",
+        "@babel/helper-compilation-targets": "^7.25.9",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.0",
+        "@babel/parser": "^7.26.0",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@babel/types": "^7.26.0",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -81,6 +150,35 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
+      "integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.25.9",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
@@ -93,6 +191,25 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
@@ -121,6 +238,32 @@
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
+      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1548,14 +1691,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.16.tgz",
       "integrity": "sha512-oh8AMIC4Y2ciKufU8hnKgs+ufgbA/dhPTACaZPM86AbwX9QwnFtSoPWEeRUj8fge+v6kFt78BXcDhAU1SrrAsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1911,6 +2054,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/browserslist": {
+      "version": "4.24.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
+      "integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1929,6 +2106,28 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001690",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001690.tgz",
+      "integrity": "sha512-5ExiE3qQN6oF8Clf8ifIDcMRCRE/dMGcETG/XGMD8/XiXm6HXQgQTh1yZYLXXpSOsEUlJm1Xr7kGULZTuGtP/w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1985,6 +2184,14 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cookie": {
       "version": "1.0.2",
@@ -2070,6 +2277,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.76",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.76.tgz",
+      "integrity": "sha512-CjVQyG7n7Sr+eBXE86HIulnL5N8xZY1sgmOPGuq/F0Rr0FJq63lg0kEtOIDfZBk44FnDLf6FUJ+dsJcuiUDdDQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/esbuild": {
       "version": "0.24.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
@@ -2108,6 +2323,17 @@
         "@esbuild/win32-arm64": "0.24.0",
         "@esbuild/win32-ia32": "0.24.0",
         "@esbuild/win32-x64": "0.24.0"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2575,6 +2801,17 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2748,6 +2985,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -2812,6 +3063,17 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/merge2": {
@@ -2906,6 +3168,14 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3495,6 +3765,38 @@
         "typescript": ">=4.8.4 <5.8.0"
       }
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3631,6 +3933,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@tanstack/eslint-plugin-query": "^5.62.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react-swc": "^3.7.2",
     "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^9.15.0",
     "eslint-config-prettier": "^9.1.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,16 +2,13 @@ import { QueryProvider, AppRouterProvider, AppThemeProvider } from './providers'
 import { GlobalStyle } from './styles';
 
 function App() {
-
   return (
-    <>
-      <AppThemeProvider>
-        <QueryProvider>
-          <GlobalStyle />
-          <AppRouterProvider />
-        </QueryProvider>
-      </AppThemeProvider>
-    </>
+    <AppThemeProvider>
+      <QueryProvider>
+        <GlobalStyle />
+        <AppRouterProvider />
+      </QueryProvider>
+    </AppThemeProvider>
   );
 }
 

--- a/src/app/layout/RootLayout.tsx
+++ b/src/app/layout/RootLayout.tsx
@@ -1,9 +1,21 @@
 import { Outlet } from 'react-router';
+import BottomNavigation from '@shared/ui/BottomNavigation.tsx';
+import styled from 'styled-components';
 
 export default function RootLayout() {
   return (
-    <>
+    <Wrapper>
       <Outlet />
-    </>
+      <BottomNavigation />
+    </Wrapper>
   );
 }
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  max-width: 440px;
+  height: 100vh;
+
+  background-color: ${({ theme }) => theme.colors.gray900};
+`;

--- a/src/app/layout/index.ts
+++ b/src/app/layout/index.ts
@@ -1,1 +1,1 @@
-export { default as RootLayout } from './RootLayout';
+export { default as RootLayout } from '@app/layout/RootLayout';

--- a/src/app/providers/AppRouterProvider.tsx
+++ b/src/app/providers/AppRouterProvider.tsx
@@ -1,5 +1,5 @@
 import { RouterProvider } from 'react-router';
-import { router } from '../routes';
+import { router } from '@app/routes';
 
 export const AppRouterProvider = () => {
   return <RouterProvider router={router} />;

--- a/src/app/providers/AppThemeProvider.tsx
+++ b/src/app/providers/AppThemeProvider.tsx
@@ -1,11 +1,7 @@
 import { ReactNode } from 'react';
 import { ThemeProvider } from 'styled-components';
-import { theme } from '../../shared/config';
+import { theme } from '@app/styles';
 
 export const AppThemeProvider = ({ children }: { children: ReactNode }) => {
-  return (
-    <ThemeProvider theme={theme}>
-      {children}
-    </ThemeProvider>
-  );
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 };

--- a/src/app/providers/QueryProvider.tsx
+++ b/src/app/providers/QueryProvider.tsx
@@ -1,7 +1,7 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { queryClient } from '../../shared/config';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ReactNode } from 'react';
 
+export const queryClient = new QueryClient();
 
 export function QueryProvider({ children }: { children: ReactNode }) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;

--- a/src/app/providers/index.ts
+++ b/src/app/providers/index.ts
@@ -1,3 +1,3 @@
-export { QueryProvider } from './QueryProvider';
-export { AppRouterProvider } from './AppRouterProvider.tsx';
-export { AppThemeProvider } from './AppThemeProvider.tsx';
+export { QueryProvider } from '@app/providers/QueryProvider';
+export { AppRouterProvider } from '@app/providers/AppRouterProvider.tsx';
+export { AppThemeProvider } from '@app/providers/AppThemeProvider.tsx';

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -25,7 +25,7 @@ export const router = createBrowserRouter([
     ],
   },
   {
-    path: 'onboarding',
+    path: '/onboarding',
     element: <OnboardingPage />,
   },
 ]);

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -11,19 +11,19 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       {
-        path: '/home',
+        path: 'home',
         element: <HomePage />,
       },
       {
-        path: '/post',
+        path: 'post',
         element: <PostPage />,
       },
       {
-        path: '/my',
+        path: 'my',
         element: <MyPage />,
       },
       {
-        path: '/onboarding',
+        path: 'onboarding',
         element: <OnboardingPage />,
       },
     ],

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -11,7 +11,7 @@ export const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       {
-        path: 'home',
+        index: true,
         element: <HomePage />,
       },
       {

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -22,10 +22,10 @@ export const router = createBrowserRouter([
         path: 'my',
         element: <MyPage />,
       },
-      {
-        path: 'onboarding',
-        element: <OnboardingPage />,
-      },
     ],
+  },
+  {
+    path: 'onboarding',
+    element: <OnboardingPage />,
   },
 ]);

--- a/src/app/routes/index.ts
+++ b/src/app/routes/index.ts
@@ -1,1 +1,1 @@
-export { router } from '../routes/Router.tsx';
+export { router } from '@app/routes/Router.tsx';

--- a/src/app/styles/colors.ts
+++ b/src/app/styles/colors.ts
@@ -1,4 +1,4 @@
-import { ColorsTypes } from '../types';
+import { ColorsTypes } from '@shared/types';
 
 export const colors: ColorsTypes = {
   green900: '#00331f',

--- a/src/app/styles/fonts.ts
+++ b/src/app/styles/fonts.ts
@@ -1,4 +1,4 @@
-import { FontsTypes } from '../types';
+import { FontsTypes } from '@shared/types';
 
 const createFontStyle = (family: string, weight: number, size: number, lineHeight: number) => `
   font-family: "${family}";
@@ -7,7 +7,6 @@ const createFontStyle = (family: string, weight: number, size: number, lineHeigh
   line-height: ${lineHeight}px;
   letter-spacing: 0%;
 `;
-
 
 export const fonts: FontsTypes = {
   heading_bold_24px: createFontStyle('Pretendard', 700, 24, 34),

--- a/src/app/styles/global-style.ts
+++ b/src/app/styles/global-style.ts
@@ -1,7 +1,6 @@
 import reset from 'styled-reset';
 import { createGlobalStyle } from 'styled-components';
 
-
 export const GlobalStyle = createGlobalStyle`
   ${reset}
   a {
@@ -10,6 +9,9 @@ export const GlobalStyle = createGlobalStyle`
 
   * {
     box-sizing: border-box;
+    -webkit-tap-highlight-color:rgba(255,255,255,0);
+    -webkit-touch-callout:none;
+    user-select:none;
   }
 
   button {

--- a/src/app/styles/index.ts
+++ b/src/app/styles/index.ts
@@ -1,1 +1,2 @@
-export { default as GlobalStyle } from './global-style.ts';
+export { default as GlobalStyle } from '@app/styles/global-style.ts';
+export { default as theme } from '@app/styles/theme.ts';

--- a/src/app/styles/theme.ts
+++ b/src/app/styles/theme.ts
@@ -1,6 +1,6 @@
 import { DefaultTheme } from 'styled-components';
-import { colors } from './colors.ts';
-import { fonts } from './fonts.ts';
+import { colors } from '@app/styles/colors.ts';
+import { fonts } from '@app/styles/fonts.ts';
 
 const theme: DefaultTheme = {
   colors,

--- a/src/pages/home/index.ts
+++ b/src/pages/home/index.ts
@@ -1,1 +1,1 @@
-export { HomePage } from './ui/HomePage';
+export { HomePage } from '@home/ui/HomePage';

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import BottomNavigation from '../../../shared/ui/BottomNavigation.tsx';
 import AppBar from '../../../shared/ui/AppBar.tsx';
 import logo from '../../../shared/assets/icon/ic-logo.svg';
 import { HeaderAction } from '../../../shared/types';
@@ -8,20 +7,9 @@ export const HomePage = () => {
   const leftHeaderAction: HeaderAction = { icon: logo, onClick: () => console.log('') };
 
   return (
-    <Wrapper>
+    <>
       <AppBar leftHeaderAction={leftHeaderAction} />
       <button>안녕</button>
-      <BottomNavigation />
-    </Wrapper>
+    </>
   );
 };
-
-const Wrapper = styled.div`
-  display: flex;;
-  flex-direction: column;
-  width: 100vw;
-  max-width: 440px;
-  height: 100vh;
-
-  background-color: ${({ theme }) => theme.colors.gray900};
-`;

--- a/src/pages/my/index.ts
+++ b/src/pages/my/index.ts
@@ -1,1 +1,1 @@
-export { MyPage } from './ui/MyPage';
+export { MyPage } from '@my/ui/MyPage';

--- a/src/pages/my/ui/MyPage.tsx
+++ b/src/pages/my/ui/MyPage.tsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import BottomNavigation from '../../../shared/ui/BottomNavigation.tsx';
 import AppBar from '../../../shared/ui/AppBar.tsx';
 import { HeaderAction } from '../../../shared/types';
 import logo from '../../../shared/assets/icon/ic-logo.svg';
@@ -14,20 +13,8 @@ export const MyPage = () => {
   ];
 
   return (
-    <Wrapper>
+    <>
       <AppBar leftHeaderAction={leftHeaderAction} rightHeaderActionArr={rightHeaderActionArr} />
-      <BottomNavigation />
-    </Wrapper>
+    </>
   );
 };
-
-
-const Wrapper = styled.div`
-  display: flex;;
-  flex-direction: column;
-  width: 100vw;
-  max-width: 440px;
-  height: 100vh;
-
-  background-color: ${({ theme }) => theme.colors.gray900};
-`;

--- a/src/pages/onboarding/index.ts
+++ b/src/pages/onboarding/index.ts
@@ -1,1 +1,1 @@
-export { OnboardingPage } from './ui/OnboardingPage';
+export { OnboardingPage } from '@onboarding/ui/OnboardingPage';

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -14,6 +14,7 @@ const Wrapper = styled.div`
   width: 100vw;
   max-width: 440px;
   height: 100vh;
+  padding: 16px 20px;
 
   background-color: ${({ theme }) => theme.colors.gray900};
 `;

--- a/src/pages/onboarding/ui/OnboardingPage.tsx
+++ b/src/pages/onboarding/ui/OnboardingPage.tsx
@@ -1,7 +1,19 @@
+import styled from 'styled-components';
+
 export const OnboardingPage = () => {
   return (
-    <div>
+    <Wrapper>
       <h1>온보딩</h1>
-    </div>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100vw;
+  max-width: 440px;
+  height: 100vh;
+
+  background-color: ${({ theme }) => theme.colors.gray900};
+`;

--- a/src/pages/post/index.ts
+++ b/src/pages/post/index.ts
@@ -1,1 +1,1 @@
-export { PostPage } from './ui/PostPage';
+export { PostPage } from '@post/ui/PostPage';

--- a/src/pages/post/ui/PostPage.tsx
+++ b/src/pages/post/ui/PostPage.tsx
@@ -1,29 +1,15 @@
 import styled from 'styled-components';
-import BottomNavigation from '../../../shared/ui/BottomNavigation.tsx';
 import AppBar from '../../../shared/ui/AppBar.tsx';
 import logo from '../../../shared/assets/icon/ic-logo.svg';
 import plus from '../../../shared/assets/icon/ic-plus.svg';
 
 export const PostPage = () => {
   const leftHeaderAction = { icon: logo, onClick: () => console.log('') };
-  const rightHeaderActionArr = [
-    { icon: plus, onClick: () => console.log('') },
-  ]
+  const rightHeaderActionArr = [{ icon: plus, onClick: () => console.log('') }];
 
   return (
-    <Wrapper>
-      <AppBar leftHeaderAction={leftHeaderAction} rightHeaderActionArr={rightHeaderActionArr}/>
-      <BottomNavigation />
-    </Wrapper>
+    <>
+      <AppBar leftHeaderAction={leftHeaderAction} rightHeaderActionArr={rightHeaderActionArr} />
+    </>
   );
 };
-
-const Wrapper = styled.div`
-  display: flex;;
-  flex-direction: column;
-  width: 100vw;
-  max-width: 440px;
-  height: 100vh;
-
-  background-color: ${({ theme }) => theme.colors.gray900};
-`;

--- a/src/shared/assets/icon/ic-home.tsx
+++ b/src/shared/assets/icon/ic-home.tsx
@@ -1,4 +1,4 @@
-import { theme } from '../../config';
+import { theme } from '@app/styles';
 import { ActiveProps } from '../../types';
 
 const IcHome = ({ $active }: ActiveProps) => {
@@ -6,12 +6,19 @@ const IcHome = ({ $active }: ActiveProps) => {
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M3 9L12 2L21 9V20C21 20.5304 20.7893 21.0391 20.4142 21.4142C20.0391 21.7893 19.5304 22 19 22H5C4.46957 22 3.96086 21.7893 3.58579 21.4142C3.21071 21.0391 3 20.5304 3 20V9Z"
-        stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2" strokeLinecap="round"
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
         strokeLinejoin="round"
       />
-      <path d="M9 22V12H15V22" stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M9 22V12H15V22"
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
-
   );
 };
 

--- a/src/shared/assets/icon/ic-inbox.tsx
+++ b/src/shared/assets/icon/ic-inbox.tsx
@@ -1,18 +1,24 @@
-import { theme } from '../../config';
+import { theme } from '@app/styles';
 import { ActiveProps } from '../../types';
 
 const IcInbox = ({ $active }: ActiveProps) => {
   return (
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M22 12H16L14 15H10L8 12H2" stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round" />
+      <path
+        d="M22 12H16L14 15H10L8 12H2"
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
       <path
         d="M5.45 5.11L2 12V18C2 18.5304 2.21071 19.0391 2.58579 19.4142C2.96086 19.7893 3.46957 20 4 20H20C20.5304 20 21.0391 19.7893 21.4142 19.4142C21.7893 19.0391 22 18.5304 22 18V12L18.55 5.11C18.3844 4.77679 18.1292 4.49637 17.813 4.30028C17.4967 4.10419 17.1321 4.0002 16.76 4H7.24C6.86792 4.0002 6.50326 4.10419 6.18704 4.30028C5.87083 4.49637 5.61558 4.77679 5.45 5.11Z"
-        stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2" strokeLinecap="round"
-        strokeLinejoin="round" />
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
-
   );
 };
 

--- a/src/shared/assets/icon/ic-user.tsx
+++ b/src/shared/assets/icon/ic-user.tsx
@@ -1,4 +1,4 @@
-import { theme } from '../../config';
+import { theme } from '@app/styles';
 import { ActiveProps } from '../../types';
 
 const IcUser = ({ $active }: ActiveProps) => {
@@ -6,10 +6,18 @@ const IcUser = ({ $active }: ActiveProps) => {
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path
         d="M20 21V19C20 17.9391 19.5786 16.9217 18.8284 16.1716C18.0783 15.4214 17.0609 15 16 15H8C6.93913 15 5.92172 15.4214 5.17157 16.1716C4.42143 16.9217 4 17.9391 4 19V21"
-        stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
       <path
         d="M12 11C14.2091 11 16 9.20914 16 7C16 4.79086 14.2091 3 12 3C9.79086 3 8 4.79086 8 7C8 9.20914 9.79086 11 12 11Z"
-        stroke={$active ? theme.colors.green500 : 'white'} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+        stroke={$active ? theme.colors.green500 : 'white'}
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
     </svg>
   );
 };

--- a/src/shared/config/index.ts
+++ b/src/shared/config/index.ts
@@ -1,2 +1,0 @@
-export { default as theme } from './theme';
-export { queryClient } from './query-client';

--- a/src/shared/config/query-client.ts
+++ b/src/shared/config/query-client.ts
@@ -1,3 +1,0 @@
-import { QueryClient } from '@tanstack/react-query';
-
-export const queryClient = new QueryClient();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -29,7 +29,8 @@
       "@home/*": ["pages/home/*"],
       "@my/*": ["pages/my/*"],
       "@onboarding/*": ["pages/onboarding/*"],
-      "@post/*": ["pages/post/*"]
+      "@post/*": ["pages/post/*"],
+      "@icon/*": ["shared/assets/icon/*"]
     }
   },
   "include": ["src"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -3,11 +3,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": [
-      "ES2020",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -24,9 +20,17 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "baseUrl": "./src",
+    "paths": {
+      "@app/*": ["app/*"],
+      "@pages/*": ["pages/*"],
+      "@shared/*": ["shared/*"],
+      "@home/*": ["pages/home/*"],
+      "@my/*": ["pages/my/*"],
+      "@onboarding/*": ["pages/onboarding/*"],
+      "@post/*": ["pages/post/*"]
+    }
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,42 @@
 import { defineConfig } from 'vite';
+import path from 'path';
+
 import react from '@vitejs/plugin-react-swc';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: [
+      { find: '@', replacement: path.resolve(__dirname, 'src') },
+      {
+        find: '@app',
+        replacement: path.resolve(__dirname, 'src/app'),
+      },
+      {
+        find: '@pages',
+        replacement: path.resolve(__dirname, 'src/pages'),
+      },
+      {
+        find: '@home',
+        replacement: path.resolve(__dirname, 'src/pages/home'),
+      },
+      {
+        find: '@my',
+        replacement: path.resolve(__dirname, 'src/pages/my'),
+      },
+      {
+        find: '@onboarding',
+        replacement: path.resolve(__dirname, 'src/pages/onboarding'),
+      },
+      {
+        find: '@post',
+        replacement: path.resolve(__dirname, 'src/pages/post'),
+      },
+      {
+        find: '@shared',
+        replacement: path.resolve(__dirname, 'src/shared'),
+      },
+    ],
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -37,6 +37,10 @@ export default defineConfig({
         find: '@shared',
         replacement: path.resolve(__dirname, 'src/shared'),
       },
+      {
+        find: '@icon',
+        replacement: path.resolve(__dirname, 'src/shared/assets/icon'),
+      },
     ],
   },
 });


### PR DESCRIPTION
## #️⃣ Issue Number
#19 

## 📝 요약(Summary)
1. pages 내부 각 페이지 별로 절대 경로 설정했습니다.
- App 폴더 내부 상대 경로로 설정돼 있는 부분 절대 경로로 수정했습니다.
2. shared/config 부분이 App 폴더 내부 초기 설정에 있는 것이 더 적합하다고 판단하여 연동했습니다.
3. @vitejs/plugin-react-swc 모듈 추가가 안돼있어서 설치했습니다.
4. index.html meta 태그 부분 zoom - in , zoom - out 되지 않게 수정했습니다. 
5. global styles 부분에 -webkit 설정 추가했습니다. 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  CSS 등 사용자 UI 디자인 변경
- [x]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [x]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [x]  파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
### 의논 사항 1
일단 피그마에 명시된 width나 height가 px 단위로 돼 있어서 최대한 반응형으로 만들고자 여러 방법을 생각해봤습니다. 
1. px를 custom 단위로 만들어주는 함수를 만든다. ->  사용하는 모바일 기기의 viewport를 이용해서 계산을 해보고자 했는데 페이지가 렌더링 될 때마다 window 객체에 접근해야 되고, 부가적인 계산 과정이 포함될 것 같아 해당 방법은 제외했습니다. 

2. postcss-px-to-viewport -> 이전 해커톤에서 만든 방식과 같은 모듈인데, 개발자가 입력한 기준의 px에 따라 vw,vh를 설정해주는 거라 제외했습니다.

-> 디자이너 분들한테 크기 단위를 %로 줄 수 있는지 여쭤봤으니까 %로 주면 그냥 그대로 쓰면 될 것 같습니다. 안되면 직접 계산을 해야 될 수도..

### 의논 사항 2
그리고 디자인 단위 사용할 때 vw,vh 와 %를 적절히 사용해야 할 것 같습니다. 예로 들면, 페이지 이동했을 때 처음 렌더링되는 컴포넌트의 root tag는 %로 사용해야 할 것 같습니다. 특히 높이 설정할 때가 신경쓸 부분인데 , 아이폰을 예시로 들면 밑에 있는 하얀 막대 부분도 vh로 포함이 돼서 SafeArea 컴포넌트 안에 %로 넣어야 되지 않을까 생각하고 있습니다.

-> 결정은 의논 후에 해보는 걸로 


## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
