### PR TITLE
🎨 style: #31 탭별 컴포넌트 구현

### DIFF
--- a/src/pages/my/components/LikedPosts.tsx
+++ b/src/pages/my/components/LikedPosts.tsx
@@ -1,5 +1,0 @@
-const LikedPosts = () => {
-  return <div style={{ height: '100%' }}>좋아요</div>;
-};
-
-export default LikedPosts;

--- a/src/pages/my/components/MyPosts.tsx
+++ b/src/pages/my/components/MyPosts.tsx
@@ -1,5 +1,0 @@
-const MyPosts = () => {
-  return <div style={{ height: '100%' }}>게시글</div>;
-};
-
-export default MyPosts;

--- a/src/pages/my/components/NoPosts.tsx
+++ b/src/pages/my/components/NoPosts.tsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+
+const NoPosts = ({ activeTab }: { activeTab: string }) => {
+  return (
+    <Wrapper>
+      <NoPostsWrapper>
+        {activeTab === 'recommend'
+          ? '결과물이 없어요'
+          : activeTab === 'post'
+            ? '게시물이 없어요'
+            : activeTab === 'like'
+              ? '좋아요한 게시글이 없어요'
+              : null}
+      </NoPostsWrapper>
+      {activeTab === 'recommend' ? (
+        <GetRecommendWrapper>추천 받으러 가기</GetRecommendWrapper>
+      ) : null}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+`;
+
+const NoPostsWrapper = styled.div`
+  font: ${({ theme }) => theme.fonts.heading_bold_24px};
+`;
+
+const GetRecommendWrapper = styled.button`
+  font: ${({ theme }) => theme.fonts.body_medium_16px};
+  color: #ffffff;
+  border: none;
+  margin-top: 16px;
+  display: flex;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+export default NoPosts;

--- a/src/pages/my/components/Post.tsx
+++ b/src/pages/my/components/Post.tsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+const Post = ({ img }: { img: string }) => {
+  return (
+    <PostWrapper>
+      <img src={img} alt="게시물" />
+    </PostWrapper>
+  );
+};
+
+const PostWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background-color: ${({ theme }) => theme.colors.gray900};
+  height: 100%;
+  :hover {
+    cursor: pointer;
+  }
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover; // 이미지가 카드 안에 꽉 차도록 설정
+  }
+`;
+
+export default Post;

--- a/src/pages/my/components/RecommendResults.tsx
+++ b/src/pages/my/components/RecommendResults.tsx
@@ -1,5 +1,0 @@
-const RecommendResults = () => {
-  return <div style={{ height: '100%' }}>추천 결과</div>;
-};
-
-export default RecommendResults;

--- a/src/pages/my/components/RenderTabContent.tsx
+++ b/src/pages/my/components/RenderTabContent.tsx
@@ -1,19 +1,19 @@
-import LikedPosts from './LikedPosts';
-import MyPosts from './MyPosts';
 import styled from 'styled-components';
-import RecommendResults from './RecommendResults';
-
+import ImgBannerBodyType from '@shared/assets/img/img-banner-body-type.png';
+import ImgBannerItem from '@shared/assets/img/img-banner-item.png';
+import ImgBannerStyle from '@shared/assets/img/img-banner-style.png';
+import TabContents from './TabContents';
 const RenderTabContent = ({ activeTab }: { activeTab: string }) => {
   return (
     <Wrapper>
       {(() => {
         switch (activeTab) {
           case 'recommend':
-            return <RecommendResults />;
+            return <TabContents img={ImgBannerBodyType} divide={3} activeTab={activeTab} />;
           case 'post':
-            return <MyPosts />;
+            return <TabContents img={ImgBannerItem} divide={2} activeTab={activeTab} />;
           case 'like':
-            return <LikedPosts />;
+            return <TabContents img={ImgBannerStyle} divide={2} activeTab={activeTab} />;
           default:
             return null;
         }
@@ -25,6 +25,7 @@ const RenderTabContent = ({ activeTab }: { activeTab: string }) => {
 export default RenderTabContent;
 
 const Wrapper = styled.div`
+  flex: 1;
+  height: 100%;
   overflow-y: auto;
-  padding-bottom: 100px;
 `;

--- a/src/pages/my/components/TabContents.tsx
+++ b/src/pages/my/components/TabContents.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+import Post from './Post';
+import { useEffect, useRef } from 'react';
+
+interface TabContentsProps {
+  img: string;
+  divide: number;
+  activeTab: string;
+}
+
+const TabContents = ({ img, divide, activeTab }: TabContentsProps) => {
+  const tabWrapperRef = useRef<HTMLDivElement | null>(null);
+
+  // activeTab 변경 시마다 스크롤을 초기화
+  useEffect(() => {
+    if (tabWrapperRef.current) {
+      tabWrapperRef.current.scrollTop = 0;
+    }
+  }, [activeTab]);
+  return (
+    <TabContentsWrapper ref={tabWrapperRef} $divide={divide}>
+      {Array.from({ length: 10 }).map((_, i) => (
+        <Post key={i} img={img} />
+      ))}
+    </TabContentsWrapper>
+  );
+};
+
+const TabContentsWrapper = styled.div<{ $divide: number }>`
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: ${({ $divide }) => `calc(100% / ${$divide})`};
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+`;
+
+export default TabContents;

--- a/src/pages/my/components/TabContents.tsx
+++ b/src/pages/my/components/TabContents.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import Post from './Post';
 import { useEffect, useRef } from 'react';
+import NoPosts from './NoPosts';
 
 interface TabContentsProps {
   img: string;
@@ -17,12 +18,17 @@ const TabContents = ({ img, divide, activeTab }: TabContentsProps) => {
       tabWrapperRef.current.scrollTop = 0;
     }
   }, [activeTab]);
-  return (
+
+  return img ? (
+    //게시글이 있을 때
     <TabContentsWrapper ref={tabWrapperRef} $divide={divide}>
       {Array.from({ length: 10 }).map((_, i) => (
         <Post key={i} img={img} />
       ))}
     </TabContentsWrapper>
+  ) : (
+    //게시글이 없을 때
+    <NoPosts activeTab={activeTab} />
   );
 };
 

--- a/src/pages/my/ui/MyPage.tsx
+++ b/src/pages/my/ui/MyPage.tsx
@@ -47,7 +47,6 @@ const Wrapper = styled.div`
   flex-direction: column;
   width: 100vw;
   max-width: 440px;
-  height: 100vh;
-
+  height: 91vh; //내비게이션바 높이만큼 빼줌
   background-color: ${({ theme }) => theme.colors.gray900};
 `;


### PR DESCRIPTION
## #️⃣ Issue Number

#31 

## 📝 요약(Summary)

- 게시글 컴포넌트 구현
- 게시글 컴포넌트 여러 개 렌더링
- 3개의 컴포넌트를 하나의 컴포넌트로 합치기
- 탭 이동 시 스크롤 초기화
- 게시글 없을 경우 화면 구현

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 💬 공유사항 to 리뷰어
- 게시글은 임의로 아무 이미지나 넣어뒀습니다.
- 피그마에 따라 추천 결과는 높이를 3등분, 내 게시물과 좋아요 누른 게시물은 높이를 2등분으로 설정했습니다.

<img src="https://github.com/user-attachments/assets/14a97a32-4c0a-4f0c-84e8-35843123be05" width="50%">  
<img src="https://github.com/user-attachments/assets/e7ba4441-1cfb-40e6-b1b0-45d7a0aa9c92" width="50%">

- 게시글이 없는 경우 컴포넌트를 아래와 같이 구현했습니다.

<img src="https://github.com/user-attachments/assets/3ea0df4b-42ab-4e20-a739-481826c226ed" width="50%">  
<img src="https://github.com/user-attachments/assets/cda39385-cbf6-408b-af56-01eb24685265" width="50%">


- 게시글을 보여줄 때 아래 두 가지 방식 중 어떤 방법이 더 나을지 궁금합니다.

1. 이미지가 잘리더라도 카드 안에 꽉 차도록 설정하는 방법  
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/2ffa47d8-2cad-460d-b070-841bd83cfbcb" />  

2. 이미지가 안 잘리게 보여주고 남은 부분을 비워두는 방법  
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/a642e04e-da73-4203-8050-e66ff212c580" />

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. (버그 수정/기능에 대한 테스트).
